### PR TITLE
propTypes and createClass deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   "dependencies": {
     "libs": "^0.1.2",
     "object-assign": "^4.0.1",
-    "swiper": "3.4.1"
+    "swiper": "3.4.1",
+    "prop-types": "^15.5.7" 
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": ">=15.5.0",
+    "react-dom": ">=0.14.0",
+    "prop-types": ">=15.5.7"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",

--- a/src/react-swiper.js
+++ b/src/react-swiper.js
@@ -4,249 +4,100 @@
       require('react'),
       require('react-dom'),
       require('swiper'),
-      require('object-assign')
+      require('object-assign'),
+      require('prop-types')
     );
   } else {
     root.ReactIDangerousSwiper = factory(
       root.React,
       root.ReactDOM,
       root.Swiper,
-      root.objectAssign
+      root.objectAssign,
+      root.PropTypes
     );
   }
-}(this, function (React, ReactDOM, Swiper, objectAssign) {
+}(this, function (React, ReactDOM, Swiper, objectAssign, PropTypes) {
   'use strict';
 
   var defaultProps = {
     containerClass: 'swiper-container',
-    wrapperClass: 'swiper-wrapper', 
+    wrapperClass: 'swiper-wrapper',
     slideClass: 'swiper-slide'
   }
 
-  var ReactIDangerousSwiper = React.createClass({
-    displayName: 'ReactIDangerousSwiper',
-    // http://idangero.us/swiper/api/#.VwH7iRJ95hE
-    propTypes: {
-      initialSlide: React.PropTypes.number,
-      direction: React.PropTypes.string,
-      speed: React.PropTypes.number,
-      setWrapperSize: React.PropTypes.bool,
-      virtualTranslate: React.PropTypes.bool,
-      width: React.PropTypes.number,
-      height: React.PropTypes.number,
-      autoHeight: React.PropTypes.bool,
-      roundLengths: React.PropTypes.bool,
-      nested: React.PropTypes.bool,
-      autoplay: React.PropTypes.number,
-      autoplayStopOnLast: React.PropTypes.bool,
-      autoplayDisableOnInteraction: React.PropTypes.bool,
-      watchSlidesProgress: React.PropTypes.bool,
-      watchSlidesVisibility: React.PropTypes.bool,
-      freeMode: React.PropTypes.bool,
-      freeModeMomentum: React.PropTypes.bool,
-      freeModeMomentumRatio: React.PropTypes.number,
-      freeModeMomentumBounce: React.PropTypes.bool,
-      freeModeMomentumBounceRatio: React.PropTypes.number,
-      freeModeMinimumVelocity: React.PropTypes.number,
-      freeModeSticky: React.PropTypes.bool,
-      effect: React.PropTypes.string,
-      fade: React.PropTypes.object,
-      cube: React.PropTypes.object,
-      coverflow: React.PropTypes.object,
-      flip: React.PropTypes.object,
-      parallax: React.PropTypes.bool,
-      spaceBetween: React.PropTypes.number,
-      slidesPerColumn: React.PropTypes.number,
-      slidesPerColumnFill: React.PropTypes.string,
-      slidesPerGroup: React.PropTypes.number,
-      centeredSlides: React.PropTypes.bool,
-      slidesOffsetBefore: React.PropTypes.number,
-      slidesOffsetAfter: React.PropTypes.number,
-      grabCursor: React.PropTypes.bool,
-      touchEventsTarget: React.PropTypes.string,
-      touchRatio: React.PropTypes.number,
-      touchAngle: React.PropTypes.number,
-      simulateTouch: React.PropTypes.bool,
-      shortSwipes: React.PropTypes.bool,
-      longSwipes: React.PropTypes.bool,
-      longSwipesRatio: React.PropTypes.number,
-      longSwipesMs: React.PropTypes.number,
-      followFinger: React.PropTypes.bool,
-      onlyExternal: React.PropTypes.bool,
-      threshold: React.PropTypes.number,
-      touchMoveStopPropagation: React.PropTypes.bool,
-      iOSEdgeSwipeDetection: React.PropTypes.bool,
-      iOSEdgeSwipeThreshold: React.PropTypes.number,
-      resistance: React.PropTypes.bool,
-      resistanceRatio: React.PropTypes.number,
-      preventClicks: React.PropTypes.bool,
-      preventClicksPropagation: React.PropTypes.bool,
-      slideToClickedSlide: React.PropTypes.bool,
-      allowSwipeToPrev: React.PropTypes.bool,
-      allowSwipeToNext: React.PropTypes.bool,
-      noSwiping: React.PropTypes.bool,
-      noSwipingClass: React.PropTypes.string,
-      uniqueNavElements: React.PropTypes.bool,
-      paginationType: React.PropTypes.string,
-      paginationHide: React.PropTypes.bool,
-      paginationClickable: React.PropTypes.bool,
-      paginationElement: React.PropTypes.string,
-      paginationBulletRender: React.PropTypes.func,
-      paginationFractionRender: React.PropTypes.func,
-      paginationProgressRender: React.PropTypes.func,
-      paginationCustomRender: React.PropTypes.func,
-      scrollbar: React.PropTypes.string,
-      scrollbarHide: React.PropTypes.bool,
-      scrollbarDraggable: React.PropTypes.bool,
-      scrollbarSnapOnRelease: React.PropTypes.bool,
-      prevButton: React.PropTypes.string,
-      nextButton: React.PropTypes.string,
-      a11y: React.PropTypes.bool,
-      prevSlideMessage: React.PropTypes.string,
-      nextSlideMessage: React.PropTypes.string,
-      firstSlideMessage: React.PropTypes.string,
-      lastSlideMessage: React.PropTypes.string,
-      paginationBulletMessage: React.PropTypes.string,
-      keyboardControl: React.PropTypes.bool,
-      mousewheelControl: React.PropTypes.bool,
-      mousewheelForceToAxis: React.PropTypes.bool,
-      mousewheelReleaseOnEdges: React.PropTypes.bool,
-      mousewheelInvert: React.PropTypes.bool,
-      mousewheelSensitivity: React.PropTypes.number,
-      hashnav: React.PropTypes.bool,
-      preloadImages: React.PropTypes.bool,
-      updateOnImagesReady: React.PropTypes.bool,
-      lazyLoading: React.PropTypes.bool,
-      lazyLoadingInPrevNext: React.PropTypes.bool,
-      lazyLoadingInPrevNextAmount: React.PropTypes.number,
-      lazyLoadingOnTransitionStart: React.PropTypes.bool,
-      loop: React.PropTypes.bool,
-      loopAdditionalSlides: React.PropTypes.number,
-      loopedSlides: React.PropTypes.number,
-      controlInverse: React.PropTypes.bool,
-      controlBy: React.PropTypes.string,
-      observer: React.PropTypes.bool,
-      observeParents: React.PropTypes.bool,
-      breakpoints: React.PropTypes.object,
-      runCallbacksOnInit: React.PropTypes.bool,
-      onInit: React.PropTypes.func,
-      onSlideChangeStart: React.PropTypes.func,
-      onSlideChangeEnd: React.PropTypes.func,
-      onSlideNextStart: React.PropTypes.func,
-      onSlideNextEnd: React.PropTypes.func,
-      onSlidePrevStart: React.PropTypes.func,
-      onSlidePrevEnd: React.PropTypes.func,
-      onTransitionStart: React.PropTypes.func,
-      onTransitionEnd: React.PropTypes.func,
-      onTouchStart: React.PropTypes.func,
-      onTouchMove: React.PropTypes.func,
-      onTouchMoveOpposite: React.PropTypes.func,
-      onSliderMove: React.PropTypes.func,
-      onTouchEnd: React.PropTypes.func,
-      onClick: React.PropTypes.func,
-      onTap: React.PropTypes.func,
-      onDoubleTap: React.PropTypes.func,
-      onImagesReady: React.PropTypes.func,
-      onProgress: React.PropTypes.func,
-      onReachBeginning: React.PropTypes.func,
-      onReachEnd: React.PropTypes.func,
-      onDestroy: React.PropTypes.func,
-      onSetTranslate: React.PropTypes.func,
-      onSetTransition: React.PropTypes.func,
-      onAutoplay: React.PropTypes.func,
-      onAutoplayStart: React.PropTypes.func,
-      onAutoplayStop: React.PropTypes.func,
-      onLazyImageLoad: React.PropTypes.func,
-      onLazyImageReady: React.PropTypes.func,
-      onPaginationRendered: React.PropTypes.func,
-      slideClass: React.PropTypes.string,
-      slideActiveClass: React.PropTypes.string,
-      slideVisibleClass: React.PropTypes.string,
-      slideDuplicateClass: React.PropTypes.string,
-      slideNextClass: React.PropTypes.string,
-      slidePrevClass: React.PropTypes.string,
-      bulletClass: React.PropTypes.string,
-      bulletActiveClass: React.PropTypes.string,
-      paginationHiddenClass: React.PropTypes.string,
-      paginationCurrentClass: React.PropTypes.string,
-      paginationTotalClass: React.PropTypes.string,
-      paginationProgressbarClass: React.PropTypes.string,
-      buttonDisabledClass: React.PropTypes.string,
-      prevButtonCustomizedClass: React.PropTypes.string,
-      nextButtonCustomizedClass: React.PropTypes.string,
-      paginationCustomizedClass: React.PropTypes.string,
-      scrollbarCustomizedClass: React.PropTypes.string
-    },
+  class ReactIDangerousSwiper extends React.Component {
+    constructor(props) {
+      super(props);
 
-    getDefaultProps: function() {
-      return defaultProps;
-    },
+      this.displayName = 'ReactIDangerousSwiper';
+      // http://idangero.us/swiper/api/#.VwH7iRJ95hE
+    }
 
-    componentDidMount: function () {
+    componentDidMount() {
       this.swiper = Swiper(ReactDOM.findDOMNode(this), objectAssign({}, this.props));
-    },
+    }
 
-    componentDidUpdate: function () {
-      if(this.props.rebuildOnUpdate && typeof this.swiper !== 'undefined') {
+    componentDidUpdate() {
+      if (this.props.rebuildOnUpdate && typeof this.swiper !== 'undefined') {
         this.swiper.destroy(true, true);
         this.swiper = Swiper(ReactDOM.findDOMNode(this), objectAssign({}, this.props));
       }
-    },
+    }
 
-    componentWillUnmount: function () {
+    componentWillUnmount() {
       if (typeof this.swiper !== 'undefined') this.swiper.destroy(true, true);
       delete this.swiper;
-    },
+    }
 
-    shouldComponentUpdate: function (nextProps) {
+    shouldComponentUpdate(nextProps) {
       return nextProps.children !== this.props.children;
-    },
+    }
 
-    componentWillReceiveProps: function (nextProps) {
-      if (this.props.rebuildOnUpdate  && typeof this.swiper !== 'undefined') {
+    componentWillReceiveProps(nextProps) {
+      if (this.props.rebuildOnUpdate && typeof this.swiper !== 'undefined') {
         this.swiper.destroy(true, true);
         this.swiper = Swiper(ReactDOM.findDOMNode(this), objectAssign({}, nextProps));
       }
-    },
+    }
 
-    validateClass: function(className) {
+    validateClass(className) {
       if (typeof className !== 'string') return '';
       return className.replace(/\.|#/g, " ").trim();
-    },
+    }
 
-    renderScrollBar: function () {
+    renderScrollBar() {
       if (!this.props.scrollbar) return false;
       var scrollbarCustomizedClass = this.validateClass(this.props.scrollbarCustomizedClass);
       var scrollbarClass = this.validateClass(this.props.scrollbar);
 
       return React.createElement('div', { className: [scrollbarClass, scrollbarCustomizedClass].join(' ') });
-    },
+    }
 
-    renderPagination: function() {
+    renderPagination() {
       if (!this.props.pagination) return false;
       var paginationCustomizedClass = this.validateClass(this.props.paginationCustomizedClass);
       var paginationClass = this.validateClass(this.props.pagination);
 
       return React.createElement('div', { className: [paginationClass, paginationCustomizedClass].join(' ') });
-    },
+    }
 
-    renderNextButton: function() {
+    renderNextButton() {
       if (!this.props.nextButton) return false;
       var nextButtonCustomizedClass = this.validateClass(this.props.nextButtonCustomizedClass);
       var nextButtonClass = this.validateClass(this.props.nextButton);
 
       return React.createElement('div', { className: [nextButtonClass, nextButtonCustomizedClass].join(' ') });
-    },
+    }
 
-    renderPrevButton: function() {
+    renderPrevButton() {
       if (!this.props.prevButton) return false;
       var prevButtonCustomizedClass = this.validateClass(this.props.prevButtonCustomizedClass);
       var prevButtonClass = this.validateClass(this.props.prevButton);
 
       return React.createElement('div', { className: [prevButtonClass, prevButtonCustomizedClass].join(' ') });
-    },
+    }
 
-    render: function() {
+    render() {
       var self = this;
       var noSwipingClass = this.props.noSwiping ? 'swiper-no-swiping' : ''
 
@@ -266,7 +117,160 @@
         self.renderPrevButton()
       );
     }
-  });
+  }
 
+  ReactIDangerousSwiper.propTypes = {
+    initialSlide: PropTypes.number,
+    direction: PropTypes.string,
+    speed: PropTypes.number,
+    setWrapperSize: PropTypes.bool,
+    virtualTranslate: PropTypes.bool,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    autoHeight: PropTypes.bool,
+    roundLengths: PropTypes.bool,
+    nested: PropTypes.bool,
+    autoplay: PropTypes.number,
+    autoplayStopOnLast: PropTypes.bool,
+    autoplayDisableOnInteraction: PropTypes.bool,
+    watchSlidesProgress: PropTypes.bool,
+    watchSlidesVisibility: PropTypes.bool,
+    freeMode: PropTypes.bool,
+    freeModeMomentum: PropTypes.bool,
+    freeModeMomentumRatio: PropTypes.number,
+    freeModeMomentumBounce: PropTypes.bool,
+    freeModeMomentumBounceRatio: PropTypes.number,
+    freeModeMinimumVelocity: PropTypes.number,
+    freeModeSticky: PropTypes.bool,
+    effect: PropTypes.string,
+    fade: PropTypes.object,
+    cube: PropTypes.object,
+    coverflow: PropTypes.object,
+    flip: PropTypes.object,
+    parallax: PropTypes.bool,
+    spaceBetween: PropTypes.number,
+    slidesPerColumn: PropTypes.number,
+    slidesPerColumnFill: PropTypes.string,
+    slidesPerGroup: PropTypes.number,
+    centeredSlides: PropTypes.bool,
+    slidesOffsetBefore: PropTypes.number,
+    slidesOffsetAfter: PropTypes.number,
+    grabCursor: PropTypes.bool,
+    touchEventsTarget: PropTypes.string,
+    touchRatio: PropTypes.number,
+    touchAngle: PropTypes.number,
+    simulateTouch: PropTypes.bool,
+    shortSwipes: PropTypes.bool,
+    longSwipes: PropTypes.bool,
+    longSwipesRatio: PropTypes.number,
+    longSwipesMs: PropTypes.number,
+    followFinger: PropTypes.bool,
+    onlyExternal: PropTypes.bool,
+    threshold: PropTypes.number,
+    touchMoveStopPropagation: PropTypes.bool,
+    iOSEdgeSwipeDetection: PropTypes.bool,
+    iOSEdgeSwipeThreshold: PropTypes.number,
+    resistance: PropTypes.bool,
+    resistanceRatio: PropTypes.number,
+    preventClicks: PropTypes.bool,
+    preventClicksPropagation: PropTypes.bool,
+    slideToClickedSlide: PropTypes.bool,
+    allowSwipeToPrev: PropTypes.bool,
+    allowSwipeToNext: PropTypes.bool,
+    noSwiping: PropTypes.bool,
+    noSwipingClass: PropTypes.string,
+    uniqueNavElements: PropTypes.bool,
+    paginationType: PropTypes.string,
+    paginationHide: PropTypes.bool,
+    paginationClickable: PropTypes.bool,
+    paginationElement: PropTypes.string,
+    paginationBulletRender: PropTypes.func,
+    paginationFractionRender: PropTypes.func,
+    paginationProgressRender: PropTypes.func,
+    paginationCustomRender: PropTypes.func,
+    scrollbar: PropTypes.string,
+    scrollbarHide: PropTypes.bool,
+    scrollbarDraggable: PropTypes.bool,
+    scrollbarSnapOnRelease: PropTypes.bool,
+    prevButton: PropTypes.string,
+    nextButton: PropTypes.string,
+    a11y: PropTypes.bool,
+    prevSlideMessage: PropTypes.string,
+    nextSlideMessage: PropTypes.string,
+    firstSlideMessage: PropTypes.string,
+    lastSlideMessage: PropTypes.string,
+    paginationBulletMessage: PropTypes.string,
+    keyboardControl: PropTypes.bool,
+    mousewheelControl: PropTypes.bool,
+    mousewheelForceToAxis: PropTypes.bool,
+    mousewheelReleaseOnEdges: PropTypes.bool,
+    mousewheelInvert: PropTypes.bool,
+    mousewheelSensitivity: PropTypes.number,
+    hashnav: PropTypes.bool,
+    preloadImages: PropTypes.bool,
+    updateOnImagesReady: PropTypes.bool,
+    lazyLoading: PropTypes.bool,
+    lazyLoadingInPrevNext: PropTypes.bool,
+    lazyLoadingInPrevNextAmount: PropTypes.number,
+    lazyLoadingOnTransitionStart: PropTypes.bool,
+    loop: PropTypes.bool,
+    loopAdditionalSlides: PropTypes.number,
+    loopedSlides: PropTypes.number,
+    controlInverse: PropTypes.bool,
+    controlBy: PropTypes.string,
+    observer: PropTypes.bool,
+    observeParents: PropTypes.bool,
+    breakpoints: PropTypes.object,
+    runCallbacksOnInit: PropTypes.bool,
+    onInit: PropTypes.func,
+    onSlideChangeStart: PropTypes.func,
+    onSlideChangeEnd: PropTypes.func,
+    onSlideNextStart: PropTypes.func,
+    onSlideNextEnd: PropTypes.func,
+    onSlidePrevStart: PropTypes.func,
+    onSlidePrevEnd: PropTypes.func,
+    onTransitionStart: PropTypes.func,
+    onTransitionEnd: PropTypes.func,
+    onTouchStart: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    onTouchMoveOpposite: PropTypes.func,
+    onSliderMove: PropTypes.func,
+    onTouchEnd: PropTypes.func,
+    onClick: PropTypes.func,
+    onTap: PropTypes.func,
+    onDoubleTap: PropTypes.func,
+    onImagesReady: PropTypes.func,
+    onProgress: PropTypes.func,
+    onReachBeginning: PropTypes.func,
+    onReachEnd: PropTypes.func,
+    onDestroy: PropTypes.func,
+    onSetTranslate: PropTypes.func,
+    onSetTransition: PropTypes.func,
+    onAutoplay: PropTypes.func,
+    onAutoplayStart: PropTypes.func,
+    onAutoplayStop: PropTypes.func,
+    onLazyImageLoad: PropTypes.func,
+    onLazyImageReady: PropTypes.func,
+    onPaginationRendered: PropTypes.func,
+    slideClass: PropTypes.string,
+    slideActiveClass: PropTypes.string,
+    slideVisibleClass: PropTypes.string,
+    slideDuplicateClass: PropTypes.string,
+    slideNextClass: PropTypes.string,
+    slidePrevClass: PropTypes.string,
+    bulletClass: PropTypes.string,
+    bulletActiveClass: PropTypes.string,
+    paginationHiddenClass: PropTypes.string,
+    paginationCurrentClass: PropTypes.string,
+    paginationTotalClass: PropTypes.string,
+    paginationProgressbarClass: PropTypes.string,
+    buttonDisabledClass: PropTypes.string,
+    prevButtonCustomizedClass: PropTypes.string,
+    nextButtonCustomizedClass: PropTypes.string,
+    paginationCustomizedClass: PropTypes.string,
+    scrollbarCustomizedClass: PropTypes.string
+  };
+
+  ReactIDangerousSwiper.defaultProps = defaultProps;
   return ReactIDangerousSwiper;
 }));


### PR DESCRIPTION
Hi,

After updating the react version in my project I noticed some console errors regarding the deprecation of createClass and calling PropTypes from the React namespace directly. I don't know if you want to include it in your code but in case you do, here it is. By the way, thanks for putting this module up here.