### PR TITLE
Update dependencies to support >= react 15.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,11 @@
   "dependencies": {
     "object-assign": "^4.1.1",
     "prop-types": "15.6.0",
-    "react": "16.0",
-    "react-dom": "16.0",
     "swiper": "4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^15.3.0 || ^16.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
@@ -46,7 +44,9 @@
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Update peer dependencies to support react 15.3.0 (first compatible version with external prop-types library)
Update dev dependencies to provide react for development purposes
Update prod dependencies to remove react as it is not necessary.