### PR TITLE
Allow activeSlideKey to slide to first child

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ var ReactIdSwiper = function (_React$Component) {
           }
         });
 
-        if (activeSlideId) {
+        if (activeSlideId !== null) {
           this.swiper.slideTo(activeSlideId);
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ export default class ReactIdSwiper extends React.Component {
         }
       });
 
-      if (activeSlideId) {
+      if (activeSlideId !== null) {
         this.swiper.slideTo(activeSlideId);
       }
     }


### PR DESCRIPTION
When using the activeSlideKey to try to slide to the first child it fails as index would be 0 which is falsey.