### PR TITLE
Added `wrapperElement` prop support for better SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ React-id-swiper's original props
 | ---  | ---  | ---           | ---         |
 | containerClass | String | swiper-container | Swiper container class name |
 | wrapperClass | String | swiper-wrapper | Swiper wrapper class name |
+| wrapperElement | String | div | Swiper wrapper element type (div, ul, etc) |
 | slideClass | String | swiper-slide | Swiper slide class name |
 | prevButtonCustomizedClass | String | '' | Swiper prev button class name |
 | nextButtonCustomizedClass | String | '' | Swiper next button class name |
@@ -50,10 +51,10 @@ yarn add react-id-swiper
 ## Recommendation
 >Swiper stylesheet file is required
 ### Use Swiper stylesheet file from CDN
-```css
+```html
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.0.6/css/swiper.css">
 ```
-```css
+```html
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Swiper/4.0.6/css/swiper.min.css">
 ```
 ### OR

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-react-id-swiper ( Newest version 1.5.6 )
+react-id-swiper ( Newest version 1.5.7 )
 ======================================
 
 > A library to use [Swiper](http://www.idangero.us/swiper/get-started/) as a ReactJs component.

--- a/lib/index.js
+++ b/lib/index.js
@@ -182,13 +182,23 @@ var ReactIdSwiper = function (_React$Component) {
       return _react2.default.cloneElement(e, _extends({}, childProps));
     }
   }, {
+    key: 'renderSlides',
+    value: function renderSlides() {
+      var _props2 = this.props,
+          children = _props2.children,
+          wrapperElement = _props2.wrapperElement,
+          wrapperClass = _props2.wrapperClass;
+
+
+      var slides = _react2.default.Children.map(children, this.renderContent);
+      return _react2.default.createElement(wrapperElement, { className: wrapperClass }, slides);
+    }
+  }, {
     key: 'render',
     value: function render() {
-      var _props2 = this.props,
-          containerClass = _props2.containerClass,
-          wrapperClass = _props2.wrapperClass,
-          children = _props2.children,
-          rtl = _props2.rtl;
+      var _props3 = this.props,
+          containerClass = _props3.containerClass,
+          rtl = _props3.rtl;
 
       var rtlProp = rtl ? { dir: 'rtl' } : {};
 
@@ -196,11 +206,7 @@ var ReactIdSwiper = function (_React$Component) {
         'div',
         _extends({ className: containerClass }, rtlProp),
         this.renderParallax(),
-        _react2.default.createElement(
-          'div',
-          { className: wrapperClass },
-          _react2.default.Children.map(children, this.renderContent)
-        ),
+        this.renderSlides(),
         this.renderPagination(),
         this.renderScrollBar(),
         this.renderNextButton(),
@@ -215,11 +221,13 @@ var ReactIdSwiper = function (_React$Component) {
 ReactIdSwiper.defaultProps = {
   containerClass: 'swiper-container',
   wrapperClass: 'swiper-wrapper',
+  wrapperElement: 'div',
   slideClass: 'swiper-slide' };
 ReactIdSwiper.propTypes = {
   // react-id-swiper original parameter
   containerClass: _propTypes2.default.string,
   wrapperClass: _propTypes2.default.string,
+  wrapperElement: _propTypes2.default.string,
   children: _propTypes2.default.oneOfType([_propTypes2.default.node, _propTypes2.default.element]),
   rebuildOnUpdate: _propTypes2.default.bool,
   shouldSwiperUpdate: _propTypes2.default.bool,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-id-swiper",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "ReactJs component for iDangerous Swiper",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export default class ReactIdSwiper extends React.Component {
   static defaultProps = {
     containerClass: 'swiper-container',
     wrapperClass: 'swiper-wrapper',
+    wrapperElement: 'div',
     slideClass: 'swiper-slide'
   }
 
@@ -17,6 +18,7 @@ export default class ReactIdSwiper extends React.Component {
     // react-id-swiper original parameter
     containerClass: PropTypes.string,
     wrapperClass: PropTypes.string,
+    wrapperElement: PropTypes.string,
     children: PropTypes.oneOfType([
       PropTypes.node,
       PropTypes.element
@@ -455,16 +457,21 @@ export default class ReactIdSwiper extends React.Component {
     return React.cloneElement(e, { ...childProps });
   }
 
+  renderSlides() {
+    const { children, wrapperElement, wrapperClass } = this.props;
+
+    const slides = React.Children.map(children, this.renderContent);
+    return React.createElement(wrapperElement, { className: wrapperClass }, slides);
+  }
+
   render() {
-    const { containerClass, wrapperClass, children, rtl } = this.props;
+    const { containerClass, rtl } = this.props;
     const rtlProp = rtl ? { dir: 'rtl' } : {};
 
     return (
       <div className={containerClass} {...rtlProp}>
         {this.renderParallax()}
-        <div className={wrapperClass}>
-          {React.Children.map(children, this.renderContent)}
-        </div>
+        {this.renderSlides()}
         {this.renderPagination()}
         {this.renderScrollBar()}
         {this.renderNextButton()}


### PR DESCRIPTION
It is impossible with current version to render slides as `<li>`, because their parent is always a div, created by this library.

This change allows to define own element name for wrapping HTML element, like `ul`, `ol` or any other required.