### PR TITLE
feat: add keyboard related props

### DIFF
--- a/src/custom.js
+++ b/src/custom.js
@@ -1,7 +1,6 @@
 /*
   NOTE: Custom version won't support those features below
   - Virtual
-  - Keyboard
   - Mouse wheel
   - Zoom
   - Lazy load image
@@ -144,6 +143,12 @@ export default class ReactIdSwiper extends Component {
 
     // breakpoints
     breakpoints: PropTypes.object,
+
+    //keyboard
+    keyboard: PropTypes.shape({
+      enabled: PropTypes.bool,
+      onlyInViewport: PropTypes.bool,
+    }),
 
     // observer
     observer: PropTypes.bool,


### PR DESCRIPTION
**Why?**
I got this error when i use react-id-swiper with using keyboard attribute.

![2019-02-25 6 20 19](https://user-images.githubusercontent.com/26598542/53326980-2ee9e180-392a-11e9-86a1-1c4661832b51.png)

**Descriptions**
So, I added related prop type .

refer: http://idangero.us/swiper/api/ keyboard control section