### PR TITLE
Do not destroy swiper instance on unmount

### DIFF
--- a/src/ReactIdSwiper.tsx
+++ b/src/ReactIdSwiper.tsx
@@ -130,7 +130,7 @@ const ReactIdSwiper: FunctionComponent<ReactIdSwiperProps> = props => {
       swiperInstanceRef.current.slideTo(slideToIndex);
     }
 
-    return () => destroySwiper();
+    return () => {};
   }, []);
 
   // Execute each time when props are updated

--- a/src/ReactIdSwiper.tsx
+++ b/src/ReactIdSwiper.tsx
@@ -130,7 +130,7 @@ const ReactIdSwiper: FunctionComponent<ReactIdSwiperProps> = props => {
       swiperInstanceRef.current.slideTo(slideToIndex);
     }
 
-    return () => {};
+    return;
   }, []);
 
   // Execute each time when props are updated


### PR DESCRIPTION
There is no need to destroy the swiper instance on `unmount`, at least I don't see. Additionally, this issue would be fixed: #389 